### PR TITLE
Feat: diminuir / aumentar 1 semitom com shift+baixo/cima

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A midi virtual piano
 
 * Right / left arrow: Next / previous instrument
 * Up / down arrow: Octave up / down
+* shift+Up / shift+down arrow: one semitone up / down
 * Pageup / Pagedown: Next / previous channel
 * Backspace: Multi voice with selected channels
 * Delete: Deletes the actual channel and go to the previous one (channel 1 can not be deleted)

--- a/src/main.py
+++ b/src/main.py
@@ -29,8 +29,8 @@ class PianoApp(wx.App):
         self.functions_keymap = {
             wx.WXK_RIGHT: lambda evt: self.piano.next_instrument(self.current_channel),
             wx.WXK_LEFT: lambda evt: self.piano.previous_instrument(self.current_channel),
-            wx.WXK_UP: lambda evt: self.piano.octave_up(self.current_channel),
-            wx.WXK_DOWN: lambda evt: self.piano.octave_down(self.current_channel),
+            wx.WXK_UP: lambda evt: self.tone_change_up(evt),
+            wx.WXK_DOWN: lambda evt: self.tone_change_down(evt),
             wx.WXK_PAGEUP: lambda evt: self.next_channel(),
             wx.WXK_PAGEDOWN: lambda evt: self.previous_channel(),
             wx.WXK_DELETE: lambda evt: self.delete_current_channel(),
@@ -100,6 +100,20 @@ class PianoApp(wx.App):
         self.piano.delete_channel(self.current_channel)
         self.active_channels.remove(self.current_channel)
         self.current_channel -= 1
+
+    def tone_change_up(self, evt):
+        key_modifier = evt.GetModifiers()
+        if key_modifier ==  wx.MOD_SHIFT:
+            self.piano.semitone_up(1, self.current_channel)
+        else:
+            self.piano.octave_up(self.current_channel)
+
+    def tone_change_down(self, evt):
+        key_modifier = evt.GetModifiers()
+        if key_modifier ==  wx.MOD_SHIFT:
+            self.piano.semitone_down(1, self.current_channel)
+        else:
+            self.piano.octave_down(self.current_channel)
 
 
 if __name__ == '__main__':

--- a/src/piano.py
+++ b/src/piano.py
@@ -51,6 +51,16 @@ class Piano:
         channel = self.get_channel(channel_number)
         channel.notes_manager.octave_up()
 
+    def semitone_down(self, total, channel_number):
+        self.all_notes_off()
+        channel = self.get_channel(channel_number)
+        channel.notes_manager.semitone_down(total)
+
+    def semitone_up(self, total, channel_number):
+        self.all_notes_off()
+        channel = self.get_channel(channel_number)
+        channel.notes_manager.semitone_up(total)
+
     def pan(self, back, channel_number):
         channel = self.get_channel(channel_number)
         direction = channel.get_direction()


### PR DESCRIPTION
## Problema

Atualmente o único controle de tom que tem é por oitava.

## Implementação

Usar setas shift+cima/baixo para subir / descer um semitom

* Criados métodos semitone_down / semitone_up nas classes piano e notes_manager, deve-se passar quantos semitons devem ser alterados
* refatorado métodos octave_up / octave_down das classes piano e notes_manager para usar os métodos semitone_up e semitone_down, mandando '12' como argumento (numero de semitons em uma oitava)